### PR TITLE
livestream_tags テーブルにインデックスを追加した

### DIFF
--- a/webapp/sql/initdb.d/10_schema.sql
+++ b/webapp/sql/initdb.d/10_schema.sql
@@ -58,6 +58,7 @@ CREATE TABLE `livestream_tags` (
   `livestream_id` BIGINT NOT NULL,
   `tag_id` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+CREATE INDEX livestream_tags_idx ON livestream_tags(`livestream_id`);
 
 -- ライブ配信視聴履歴
 CREATE TABLE `livestream_viewers_history` (


### PR DESCRIPTION
Exec Time は  2ms  - 212ms
Rows sent (結果をクライアントに送信した回数) の平均は  3.01 で, Rows examine(実行されたクエリーがフェッチしたデータの行数) の平均は10.92k

```
# Query 1: 34.02 QPS, 1.82x concurrency, ID 0xF7144185D9A142A426A36DC55C1D2623 at byte 14876848
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.03
# Time range: 2024-11-24T14:02:52 to 2024-11-24T14:04:37
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          6    3572
# Exec time     39    191s     2ms   212ms    54ms   105ms    41ms    68ms
# Lock time      3    26ms       0     9ms     7us     1us   168us     1us
# Rows sent     11  10.49k       0      11    3.01    4.96    1.91    1.96
# Rows examine  39  37.67M  10.71k  10.92k  10.80k  10.80k     106  10.29k
# Query size     3 195.15k      53      56   55.95   54.21    0.16   54.21
# String:
# Databases    isupipe
# Hosts        172.18.0.4
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################
#  10ms  ################################################################
# 100ms  ###################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livestream_tags'\G
#    SHOW CREATE TABLE `isupipe`.`livestream_tags`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM livestream_tags WHERE livestream_id = 7500\G
```