### PR TITLE
themes テーブルにインデックスを追加した

### DIFF
--- a/webapp/sql/initdb.d/10_schema.sql
+++ b/webapp/sql/initdb.d/10_schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE `themes` (
   `user_id` BIGINT NOT NULL,
   `dark_mode` BOOLEAN NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+CREATE INDEX themes_user_id ON themes(`user_id`);
 
 -- ライブ配信
 CREATE TABLE `livestreams` (


### PR DESCRIPTION

```
# Query 2: 69.07 QPS, 0.57x concurrency, ID 0x38BC86A45F31C6B1EE324671506C898A at byte 13304822
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-24T14:57:32 to 2024-11-24T14:59:16
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         12    7183
# Exec time     15     59s   275us    81ms     8ms    20ms     7ms     8ms
# Lock time      2    37ms       0     7ms     5us     1us   103us     1us
# Rows sent      7   7.01k       1       1       1       1       0       1
# Rows examine  12   7.57M    1000   1.19k   1.08k   1.14k   73.37   1.09k
# Query size     5 285.61k      38      41   40.72   40.45    0.86   40.45
# String:
# Databases    isupipe
# Hosts        172.18.0.3
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us  ###########################################
#   1ms  ##########################################################
#  10ms  ################################################################
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'themes'\G
#    SHOW CREATE TABLE `isupipe`.`themes`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM themes WHERE user_id = 22\G
```