### PR TITLE
icons テーブルの user_id にIndexを追加した

### DIFF
--- a/webapp/sql/initdb.d/10_schema.sql
+++ b/webapp/sql/initdb.d/10_schema.sql
@@ -15,7 +15,8 @@ CREATE TABLE `icons` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `user_id` BIGINT NOT NULL,
   `image` LONGBLOB NOT NULL,
-  `hash` TEXT NOT NULL
+  `hash` TEXT NOT NULL,
+  INDEX `idx_icons_user_id` (`user_id`)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- ユーザごとのカスタムテーマ


### PR DESCRIPTION

```
# Query 1: 0.07 QPS, 0.00x concurrency, ID 0xC1888D7D9588762CC37465265F7F7D0B at byte 4383210
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.02
# Time range: 2024-12-30T14:17:05 to 2025-01-06T12:59:23
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         28   40658
# Exec time     33    874s    71us   366ms    22ms    61ms    21ms    15ms
# Lock time      0   180ms       0    23ms     4us     1us   146us     1us
# Rows sent      4  31.24k       0       1    0.79    0.99    0.41    0.99
# Rows examine   2   6.25M       0     352  161.13  299.03   90.13  151.03
# Query size    14   1.93M      47      50   49.77   49.17    0.95   49.17
# String:
# Databases    isupipe
# Hosts        172.20.0.4 (35468/87%), 172.20.0.3 (5190/12%)
# Users        isucon
# Query_time distribution
#   1us
#  10us  #
# 100us  ######
#   1ms  ##################################
#  10ms  ################################################################
# 100ms  #
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'icons'\G
#    SHOW CREATE TABLE `isupipe`.`icons`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT image, hash FROM icons WHERE user_id = 661\G
```